### PR TITLE
Add pip-installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Why not? Use your imagination!
 * requests library
 * free time
 
+## Install it with pip
+```bash
+pip install git+https://github.com/David-Lor/ThisPersonDoesNotExistAPI
+```
+
 ## Usage
 
 ### Get a person using function

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+from distutils.core import setup
+
+setup(name="ThisPersonDoesNotExistAPI",
+      version="1.0.0",
+      description="Unofficial API for the ThisPersonDoesNotExist website.",
+      license='Apache-2.0',
+      author="David Lorenzo",
+      author_email="",
+      url='https://github.com/David-Lor/ThisPersonDoesNotExistAPI',
+      python_requires=">=3.6",
+      install_requires=[
+        "requests",
+      ],
+)


### PR DESCRIPTION
Add the possibility to install it with
```bash
pip install git+https://github.com/David-Lor/ThisPersonDoesNotExistAPI
```
This will allow developers to use it without needing to clone the repo.